### PR TITLE
42164 transfer add securityPolicyName2025_03,securityPolicyNam

### DIFF
--- a/.changelog/42164.txt
+++ b/.changelog/42164.txt
@@ -1,0 +1,5 @@
+```release-note:enhancement
+resource/aws_transfer_server: Add `TransferSecurityPolicy-2025-03` as a valid value for `security_policy_name`
+resource/aws_transfer_server: Add `TransferSecurityPolicy-FIPS-2025-03` as a valid value for `security_policy_name`
+resource/aws_transfer_server: Add `TransferSecurityPolicy-SshAuditCompliant-2025-02` as a valid value for `security_policy_name`
+```

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -1281,6 +1281,6 @@ func (securityPolicyName) Values() []securityPolicyName {
 		securityPolicyNameRestricted_2018_11,
 		securityPolicyNameRestricted_2020_06,
 		securityPolicyNameRestricted_2024_06,
-		securityPolicyNameSshAuditCompliant_2025_02
+		securityPolicyNameSshAuditCompliant_2025_02,
 	}
 }

--- a/internal/service/transfer/server.go
+++ b/internal/service/transfer/server.go
@@ -1243,20 +1243,24 @@ func flattenWorkflowDetail(apiObjects []awstypes.WorkflowDetail) []any {
 type securityPolicyName string
 
 const (
-	securityPolicyName2018_11             securityPolicyName = "TransferSecurityPolicy-2018-11"
-	securityPolicyName2020_06             securityPolicyName = "TransferSecurityPolicy-2020-06"
-	securityPolicyName2022_03             securityPolicyName = "TransferSecurityPolicy-2022-03"
-	securityPolicyName2023_05             securityPolicyName = "TransferSecurityPolicy-2023-05"
-	securityPolicyName2024_01             securityPolicyName = "TransferSecurityPolicy-2024-01"
-	securityPolicyNameFIPS_2020_06        securityPolicyName = "TransferSecurityPolicy-FIPS-2020-06"
-	securityPolicyNameFIPS_2023_05        securityPolicyName = "TransferSecurityPolicy-FIPS-2023-05"
-	securityPolicyNameFIPS_2024_01        securityPolicyName = "TransferSecurityPolicy-FIPS-2024-01"
-	securityPolicyNameFIPS_2024_05        securityPolicyName = "TransferSecurityPolicy-FIPS-2024-05"
-	securityPolicyNamePQ_SSH_2023_04      securityPolicyName = "TransferSecurityPolicy-PQ-SSH-Experimental-2023-04"
-	securityPolicyNamePQ_SSH_FIPS_2023_04 securityPolicyName = "TransferSecurityPolicy-PQ-SSH-FIPS-Experimental-2023-04"
-	securityPolicyNameRestricted_2018_11  securityPolicyName = "TransferSecurityPolicy-Restricted-2018-11"
-	securityPolicyNameRestricted_2020_06  securityPolicyName = "TransferSecurityPolicy-Restricted-2020-06"
-	securityPolicyNameRestricted_2024_06  securityPolicyName = "TransferSecurityPolicy-Restricted-2024-06"
+	securityPolicyName2018_11                   securityPolicyName = "TransferSecurityPolicy-2018-11"
+	securityPolicyName2020_06                   securityPolicyName = "TransferSecurityPolicy-2020-06"
+	securityPolicyName2022_03                   securityPolicyName = "TransferSecurityPolicy-2022-03"
+	securityPolicyName2023_05                   securityPolicyName = "TransferSecurityPolicy-2023-05"
+	securityPolicyName2024_01                   securityPolicyName = "TransferSecurityPolicy-2024-01"
+	securityPolicyName2025_03                   securityPolicyName = "TransferSecurityPolicy-2025-03"
+	securityPolicyNameFIPS_2020_06              securityPolicyName = "TransferSecurityPolicy-FIPS-2020-06"
+	securityPolicyNameFIPS_2023_05              securityPolicyName = "TransferSecurityPolicy-FIPS-2023-05"
+	securityPolicyNameFIPS_2024_01              securityPolicyName = "TransferSecurityPolicy-FIPS-2024-01"
+	securityPolicyNameFIPS_2024_05              securityPolicyName = "TransferSecurityPolicy-FIPS-2024-05"
+	securityPolicyNameFIPS_2024_10              securityPolicyName = "TransferSFTPConnectorSecurityPolicy-FIPS-2024-10"
+	securityPolicyNameFIPS_2025_03              securityPolicyName = "TransferSecurityPolicy-FIPS-2025-03"
+	securityPolicyNamePQ_SSH_2023_04            securityPolicyName = "TransferSecurityPolicy-PQ-SSH-Experimental-2023-04"
+	securityPolicyNamePQ_SSH_FIPS_2023_04       securityPolicyName = "TransferSecurityPolicy-PQ-SSH-FIPS-Experimental-2023-04"
+	securityPolicyNameRestricted_2018_11        securityPolicyName = "TransferSecurityPolicy-Restricted-2018-11"
+	securityPolicyNameRestricted_2020_06        securityPolicyName = "TransferSecurityPolicy-Restricted-2020-06"
+	securityPolicyNameRestricted_2024_06        securityPolicyName = "TransferSecurityPolicy-Restricted-2024-06"
+	securityPolicyNameSshAuditCompliant_2025_02 securityPolicyName = "TransferSecurityPolicy-SshAuditCompliant-2025-02"
 )
 
 func (securityPolicyName) Values() []securityPolicyName {
@@ -1266,14 +1270,17 @@ func (securityPolicyName) Values() []securityPolicyName {
 		securityPolicyName2022_03,
 		securityPolicyName2023_05,
 		securityPolicyName2024_01,
+		securityPolicyName2025_03,
 		securityPolicyNameFIPS_2020_06,
 		securityPolicyNameFIPS_2023_05,
 		securityPolicyNameFIPS_2024_01,
 		securityPolicyNameFIPS_2024_05,
+		securityPolicyNameFIPS_2025_03,
 		securityPolicyNamePQ_SSH_2023_04,
 		securityPolicyNamePQ_SSH_FIPS_2023_04,
 		securityPolicyNameRestricted_2018_11,
 		securityPolicyNameRestricted_2020_06,
 		securityPolicyNameRestricted_2024_06,
+		securityPolicyNameSshAuditCompliant_2025_02
 	}
 }

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -267,6 +267,13 @@ func testAccServer_securityPolicy(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-2025-03"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-2025-03"),
+				),
+			},
+			{
 				Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-PQ-SSH-Experimental-2023-04"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerExists(ctx, resourceName, &conf),
@@ -347,10 +354,24 @@ func testAccServer_securityPolicyFIPS(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-FIPS-2025-03"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-FIPS-2025-03"),
+				),
+			},
+			{
 				Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-PQ-SSH-FIPS-Experimental-2023-04"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-PQ-SSH-FIPS-Experimental-2023-04"),
+				),
+			},
+			{
+				Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-SshAuditCompliant-2025-02"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-SshAuditCompliant-2025-02"),
 				),
 			},
 		},

--- a/internal/service/transfer/server_test.go
+++ b/internal/service/transfer/server_test.go
@@ -294,6 +294,13 @@ func testAccServer_securityPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-Restricted-2020-06"),
 				),
 			},
+			{
+				Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-SshAuditCompliant-2025-02"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerExists(ctx, resourceName, &conf),
+					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-SshAuditCompliant-2025-02"),
+				),
+			},
 			/*
 				{
 					Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-Restricted-2024-06"),
@@ -365,13 +372,6 @@ func testAccServer_securityPolicyFIPS(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServerExists(ctx, resourceName, &conf),
 					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-PQ-SSH-FIPS-Experimental-2023-04"),
-				),
-			},
-			{
-				Config: testAccServerConfig_securityPolicy(rName, "TransferSecurityPolicy-SshAuditCompliant-2025-02"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckServerExists(ctx, resourceName, &conf),
-					resource.TestCheckResourceAttr(resourceName, "security_policy_name", "TransferSecurityPolicy-SshAuditCompliant-2025-02"),
 				),
 			},
 		},

--- a/website/docs/r/transfer_server.html.markdown
+++ b/website/docs/r/transfer_server.html.markdown
@@ -153,15 +153,18 @@ This resource supports the following arguments:
     * `TransferSecurityPolicy-2022-03`
     * `TransferSecurityPolicy-2023-05`
     * `TransferSecurityPolicy-2024-01`
+    * `TransferSecurityPolicy-2025-03`
     * `TransferSecurityPolicy-FIPS-2020-06`
     * `TransferSecurityPolicy-FIPS-2023-05`
     * `TransferSecurityPolicy-FIPS-2024-01`
     * `TransferSecurityPolicy-FIPS-2024-05`
+    * `TransferSecurityPolicy-FIPS-2025-03`
     * `TransferSecurityPolicy-PQ-SSH-Experimental-2023-04`
     * `TransferSecurityPolicy-PQ-SSH-FIPS-Experimental-2023-04`
     * `TransferSecurityPolicy-Restricted-2018-11`
     * `TransferSecurityPolicy-Restricted-2020-06`
     * `TransferSecurityPolicy-Restricted-2024-06`
+    * `TransferSecurityPolicy-SshAuditCompliant-2025-02`
 
    See [Security policies for AWS Transfer Family servers](https://docs.aws.amazon.com/transfer/latest/userguide/security-policies.html) for details.
 * `structured_log_destinations` - (Optional) A set of ARNs of destinations that will receive structured logs from the transfer server such as CloudWatch Log Group ARNs. If provided this enables the transfer server to emit structured logs to the specified locations.


### PR DESCRIPTION
eFIPS_2025_03,securityPolicyNameSshAuditCompliant_2025_02 support to server.go

<!---
See what makes a good Pull Request at: https://hashicorp.github.io/terraform-provider-aws/raising-a-pull-request/
--->
### Description

transfer service add support for securityPolicyName2025_03, securityPolicyNameFIPS_2025_03, securityPolicyNameSshAuditCompliant_2025_02


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #42164
--->

Closes #42164

### References
https://docs.aws.am
azon.com/transfer/latest/userguide/security-policies.html#security-policy-transferSecurityPolicy-SshAuditCompliant-2025-02


```
🕙[ 20:43:48 ] ➜ aws transfer list-security-policies
{
    "SecurityPolicyNames": [
        "TransferSFTPConnectorSecurityPolicy-2023-07",
        "TransferSFTPConnectorSecurityPolicy-2024-03",
        "TransferSFTPConnectorSecurityPolicy-FIPS-2024-10",
        "TransferSecurityPolicy-2018-11",
        "TransferSecurityPolicy-2020-06",
        "TransferSecurityPolicy-2022-03",
        "TransferSecurityPolicy-2023-05",
        "TransferSecurityPolicy-2024-01",
        "TransferSecurityPolicy-2025-03",
        "TransferSecurityPolicy-FIPS-2020-06",
        "TransferSecurityPolicy-FIPS-2023-05",
        "TransferSecurityPolicy-FIPS-2024-01",
        "TransferSecurityPolicy-FIPS-2024-05",
        "TransferSecurityPolicy-FIPS-2025-03",
        "TransferSecurityPolicy-PQ-SSH-Experimental-2023-04",
        "TransferSecurityPolicy-PQ-SSH-FIPS-Experimental-2023-04",
        "TransferSecurityPolicy-Restricted-2018-11",
        "TransferSecurityPolicy-Restricted-2020-06",
        "TransferSecurityPolicy-SshAuditCompliant-2025-02"
    ]
}

```


### Output from Acceptance Testing
<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->

```console
🕙[ 20:47:52 ] ➜ make test PKG=transfer
make: Verifying source code with gofmt...
==> Checking that code complies with gofmt requirements...
make: Running unit tests...
go1.23.8 test -count 1 ./internal/service/transfer/...  -timeout=15m -vet=off
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/transfer	15.695s



...
```
